### PR TITLE
Extension of Message Manager to handle channel subscription and message selection

### DIFF
--- a/src/main/java/adf/agent/Agent.java
+++ b/src/main/java/adf/agent/Agent.java
@@ -135,6 +135,7 @@ public abstract class Agent<E extends StandardEntity> extends AbstractAgent<Stan
 		this.agentInfo.recordThinkStartTime();
 		this.agentInfo.setTime(time);
 
+
 		if (1 == time) {
 			if (this.communicationModule != null) {
 				ConsoleOutput.out(ConsoleOutput.State.ERROR, "[ERROR ] Loader is not found.");
@@ -146,8 +147,17 @@ public abstract class Agent<E extends StandardEntity> extends AbstractAgent<Stan
 			this.messageManager.registerMessageBundle(new StandardMessageBundle());
 		}
 
-		if (time <= this.ignoreTime) {
-			super.send(new AKSubscribe(this.getID(), time, 1));
+		// agents can subscribe after ignore time
+		if (time >= ignoreTime) {
+			this.messageManager.subscribe(this.agentInfo, this.worldInfo, this.scenarioInfo);
+
+			if (!this.messageManager.getIsSubscribed()) {
+				int[] channelsToSubscribe = this.messageManager.getChannels();
+				if (channelsToSubscribe != null) {
+					super.send(new AKSubscribe(this.getID(), time, channelsToSubscribe));
+					this.messageManager.setIsSubscribed(true);
+				}
+			}
 		}
 
 		this.agentInfo.setHeard(heard);

--- a/src/main/java/adf/agent/communication/standard/StandardCommunicationModule.java
+++ b/src/main/java/adf/agent/communication/standard/StandardCommunicationModule.java
@@ -18,13 +18,12 @@ import javax.annotation.Nonnull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
+import java.util.List;
 
 public class StandardCommunicationModule extends CommunicationModule {
 	final private int ESCAPE_CHAR = 0x41;
 	final private int SIZE_ID = 5;
 	final private int SIZE_TTL = 3;
-
-	private int channel = 1;
 
 	@Override
 	public void receive(@Nonnull Agent agent, @Nonnull MessageManager messageManager) {
@@ -105,52 +104,54 @@ public class StandardCommunicationModule extends CommunicationModule {
 	public void send(@Nonnull Agent agent, @Nonnull MessageManager messageManager) {
 		final int voiceLimitBytes = agent.scenarioInfo.getVoiceMessagesSize();
 		int voiceMessageLeft = voiceLimitBytes;
-		//BitOutputStream voiceMessageStream = new BitOutputStream();
 		ByteArrayOutputStream voiceMessageStream = new ByteArrayOutputStream();
 
 		Message[] messages = new Message[1];
 
-		for (CommunicationMessage message : messageManager.getSendMessageList()) {
-			int messageClassIndex = messageManager.getMessageClassIndex(message);
+		List<List<CommunicationMessage>> sendMessageList = messageManager.getSendMessageList();
+		for (int channel = 0; channel < sendMessageList.size(); channel++) {
+			for (CommunicationMessage message : sendMessageList.get(channel)) {
+				int messageClassIndex = messageManager.getMessageClassIndex(message);
 
-			BitOutputStream bitOutputStream = new BitOutputStream();
-			bitOutputStream.writeBits(messageClassIndex, SIZE_ID);
+				BitOutputStream bitOutputStream = new BitOutputStream();
+				bitOutputStream.writeBits(messageClassIndex, SIZE_ID);
 
-			if (!message.isRadio()) {
-				bitOutputStream.writeBits(((StandardMessage) message).getTTL(), SIZE_TTL);
-			}
+				if (channel == 0) {
+					bitOutputStream.writeBits(((StandardMessage) message).getTTL(), SIZE_TTL);
+				}
 
-			bitOutputStream.writeBits(message.toBitOutputStream());
+				bitOutputStream.writeBits(message.toBitOutputStream());
 
-			if (message.isRadio()) {
-				messages[0] = new AKSpeak(agent.getID(), agent.agentInfo.getTime(), channel, bitOutputStream.toByteArray());
-				agent.send(messages);
-			} else {
-				int messageSize = (int) Math.ceil(((double) bitOutputStream.size()) / 8.0);
-				if (messageSize <= voiceMessageLeft) {
-					byte[] messageData = bitOutputStream.toByteArray();
-					ByteArrayOutputStream escapedMessage = new ByteArrayOutputStream();
-					for (int i = 0; i < messageSize; i++) {
-						if (messageData[i] == ESCAPE_CHAR) {
-							escapedMessage.write(ESCAPE_CHAR);
+				if (channel > 0) {
+					messages[0] = new AKSpeak(agent.getID(), agent.agentInfo.getTime(), channel, bitOutputStream.toByteArray());
+					agent.send(messages);
+				} else {
+					// voice channel
+					int messageSize = (int) Math.ceil(((double) bitOutputStream.size()) / 8.0);
+					if (messageSize <= voiceMessageLeft) {
+						byte[] messageData = bitOutputStream.toByteArray();
+						ByteArrayOutputStream escapedMessage = new ByteArrayOutputStream();
+						for (int i = 0; i < messageSize; i++) {
+							if (messageData[i] == ESCAPE_CHAR) {
+								escapedMessage.write(ESCAPE_CHAR);
+							}
+							escapedMessage.write(messageData[i]);
 						}
-						escapedMessage.write(messageData[i]);
-					}
-					escapedMessage.toByteArray();
-					escapedMessage.write(ESCAPE_CHAR);
-					if (escapedMessage.size() <= voiceMessageLeft) {
-						voiceMessageLeft -= escapedMessage.size();
-						try {
-							voiceMessageStream.write(escapedMessage.toByteArray());
-						} catch (IOException e) {
-							e.printStackTrace();
+						escapedMessage.toByteArray();
+						escapedMessage.write(ESCAPE_CHAR);
+						if (escapedMessage.size() <= voiceMessageLeft) {
+							voiceMessageLeft -= escapedMessage.size();
+							try {
+								voiceMessageStream.write(escapedMessage.toByteArray());
+							} catch (IOException e) {
+								e.printStackTrace();
+							}
 						}
 					}
 				}
 			}
 		}
 
-		//messages[0] = new AKSay(agent.getID(), agent.agentInfo.getTime(), voiceMessageStream.toByteArray());
 		if (voiceMessageStream.size() > 0) {
 			messages[0] = new AKSpeak(agent.getID(), agent.agentInfo.getTime(), 0, voiceMessageStream.toByteArray());
 			agent.send(messages);

--- a/src/main/java/adf/agent/communication/standard/bundle/StandardMessageBundle.java
+++ b/src/main/java/adf/agent/communication/standard/bundle/StandardMessageBundle.java
@@ -16,7 +16,6 @@ public class StandardMessageBundle extends MessageBundle {
 	public List<Class<? extends CommunicationMessage>> getMessageClassList() {
 		List<Class<? extends CommunicationMessage>> messageClassList = new ArrayList<>();
 
-		//messageClassList.add(MessageDummy.class);
 		//information
 		messageClassList.add(MessageAmbulanceTeam.class);
 		messageClassList.add(MessageBuilding.class);
@@ -33,10 +32,4 @@ public class StandardMessageBundle extends MessageBundle {
 
 		return messageClassList;
 	}
-
-	@Override
-	public MessageCoordinator getMessageCoordinator() {
-		return new StandardMessageCoordinator();
-	}
-
 }

--- a/src/main/java/adf/agent/communication/standard/bundle/StandardMessageCoordinator.java
+++ b/src/main/java/adf/agent/communication/standard/bundle/StandardMessageCoordinator.java
@@ -8,36 +8,58 @@ import adf.component.communication.CommunicationMessage;
 import adf.component.communication.MessageCoordinator;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public class StandardMessageCoordinator extends MessageCoordinator {
 	@Override
-	public void coordinate(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, MessageManager messageManager, ArrayList<CommunicationMessage> sendMessageList) {
-		ArrayList<StandardMessage> standardMessageLowList = new ArrayList<>();
-		ArrayList<StandardMessage> standardMessageNormalList = new ArrayList<>();
-		ArrayList<StandardMessage> standardMessageHighList = new ArrayList<>();
+	public void coordinate(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, MessageManager messageManager,
+												 ArrayList<CommunicationMessage> sendMessageList, List<List<CommunicationMessage>> channelSendMessageList) {
+		ArrayList<StandardMessage> standardRadioMessageLowList = new ArrayList<>();
+		ArrayList<StandardMessage> standardRadioMessageNormalList = new ArrayList<>();
+		ArrayList<StandardMessage> standardRadioMessageHighList = new ArrayList<>();
+
+		ArrayList<StandardMessage> standardVoiceMessageLowList = new ArrayList<>();
+		ArrayList<StandardMessage> standardVoiceMessageNormalList = new ArrayList<>();
+		ArrayList<StandardMessage> standardVoiceMessageHighList = new ArrayList<>();
+
 		for (CommunicationMessage msg : sendMessageList) {
 			if (msg instanceof StandardMessage) {
 				StandardMessage m = (StandardMessage) msg;
 				switch (m.getSendingPriority()) {
 					case LOW:
-						standardMessageLowList.add(m);
+						if (m.isRadio()) {
+							standardRadioMessageLowList.add(m);
+						} else {
+							standardVoiceMessageLowList.add(m);
+						}
 						break;
 					case NORMAL:
-						standardMessageNormalList.add(m);
+						if (m.isRadio()) {
+							standardRadioMessageNormalList.add(m);
+						} else {
+							standardVoiceMessageNormalList.add(m);
+						}
 						break;
 					case HIGH:
-						standardMessageHighList.add(m);
+						if (m.isRadio()) {
+							standardRadioMessageHighList.add(m);
+						} else {
+							standardVoiceMessageHighList.add(m);
+						}
 						break;
 				}
 			}
 		}
 
-		sendMessageList.removeAll(standardMessageHighList);
-		sendMessageList.removeAll(standardMessageNormalList);
-		sendMessageList.removeAll(standardMessageLowList);
+		// all radio messages are sent over the channel 1 (this is the default implementation)
+		channelSendMessageList.get(1).addAll(standardRadioMessageHighList);
+		channelSendMessageList.get(1).addAll(standardRadioMessageNormalList);
+		channelSendMessageList.get(1).addAll(standardRadioMessageLowList);
 
-		sendMessageList.addAll(standardMessageHighList);
-		sendMessageList.addAll(standardMessageNormalList);
-		sendMessageList.addAll(standardMessageLowList);
+		// set the voice channel messages
+		channelSendMessageList.get(0).addAll(standardVoiceMessageHighList);
+		channelSendMessageList.get(0).addAll(standardVoiceMessageNormalList);
+		channelSendMessageList.get(0).addAll(standardVoiceMessageLowList);
+
 	}
 }

--- a/src/main/java/adf/agent/info/ScenarioInfo.java
+++ b/src/main/java/adf/agent/info/ScenarioInfo.java
@@ -145,6 +145,14 @@ public class ScenarioInfo {
 		return config.getIntValue("comms.channels.count");
 	}
 
+	public int getCommsChannelBandwidth(int channel) {
+		if (channel < getCommsChannelsCount()) {
+			return config.getIntValue("comms.channels."+channel+".bandwidth");
+		} else {
+			return 0;
+		}
+	}
+
 	@Nullable
 	public String getKernelPerception() {
 		return config.getValue("kernel.perception");

--- a/src/main/java/adf/agent/office/Office.java
+++ b/src/main/java/adf/agent/office/Office.java
@@ -24,6 +24,8 @@ public abstract class Office<E extends StandardEntity> extends Agent<E> {
 
 		this.agentInfo = new AgentInfo(this, model);
 		this.moduleManager = new ModuleManager(this.agentInfo, this.worldInfo, this.scenarioInfo, this.moduleConfig, this.developData);
+		this.messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.CenterChannelSubscriber", "adf.component.communication.ChannelSubscriber"));
+		this.messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.CenterMessageCoordinator", "adf.agent.communication.standard.bundle.StandardMessageCoordinator"));
 
 		rootTacticsCenter.initialize(this.agentInfo, this.worldInfo, this.scenarioInfo, this.moduleManager, this.messageManager, this.developData);
 

--- a/src/main/java/adf/agent/platoon/Platoon.java
+++ b/src/main/java/adf/agent/platoon/Platoon.java
@@ -26,6 +26,8 @@ public abstract class Platoon<E extends StandardEntity> extends Agent<E> {
 
 		this.agentInfo = new AgentInfo(this, this.model);
 		this.moduleManager = new ModuleManager(this.agentInfo, this.worldInfo, this.scenarioInfo, this.moduleConfig, this.developData);
+		this.messageManager.setChannelSubscriber(moduleManager.getChannelSubscriber("MessageManager.PlatoonChannelSubscriber", "adf.component.communication.ChannelSubscriber"));
+		this.messageManager.setMessageCoordinator(moduleManager.getMessageCoordinator("MessageManager.PlatoonMessageCoordinator", "adf.agent.communication.standard.bundle.StandardMessageCoordinator"));
 
 		this.rootTactics.initialize(this.agentInfo, this.worldInfo, this.scenarioInfo, this.moduleManager, this.messageManager, this.developData);
 

--- a/src/main/java/adf/component/communication/ChannelSubscriber.java
+++ b/src/main/java/adf/component/communication/ChannelSubscriber.java
@@ -1,0 +1,21 @@
+package adf.component.communication;
+
+import adf.agent.communication.MessageManager;
+import adf.agent.info.AgentInfo;
+import adf.agent.info.ScenarioInfo;
+import adf.agent.info.WorldInfo;
+
+/**
+ * Created by okan on 14.01.2018.
+ */
+public class ChannelSubscriber {
+	public void subscribe(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo,
+																 MessageManager messageManager) {
+		// default channel subscriber subscribes to only channel 1
+		if (agentInfo.getTime() == 1) {
+			int[] channels = new int[1];
+			channels[0] = 1;
+			messageManager.subscribeToChannels(channels);
+		}
+	}
+}

--- a/src/main/java/adf/component/communication/MessageBundle.java
+++ b/src/main/java/adf/component/communication/MessageBundle.java
@@ -4,6 +4,4 @@ import java.util.List;
 
 abstract public class MessageBundle {
 	abstract public List<Class<? extends CommunicationMessage>> getMessageClassList();
-
-	abstract public MessageCoordinator getMessageCoordinator();
 }

--- a/src/main/java/adf/component/communication/MessageCoordinator.java
+++ b/src/main/java/adf/component/communication/MessageCoordinator.java
@@ -11,5 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 abstract public class MessageCoordinator {
-	abstract public void coordinate(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo, MessageManager messageManager, ArrayList<CommunicationMessage> sendMessageList);
+	abstract public void coordinate(AgentInfo agentInfo, WorldInfo worldInfo, ScenarioInfo scenarioInfo,
+																	MessageManager messageManager, ArrayList<CommunicationMessage> sendMessageList,
+																	List<List<CommunicationMessage>> channelSendMessageList);
 }


### PR DESCRIPTION
The Extension of Message Manager handles the channel subscription and the message selection. The current message manager only subscribes to the channel 1 and the current message selection favors command messages over information messages.

With this change the teams will be able to develop their own channel subscription and message selection strategy. We have sample subscription and selection module. Sample channel subscription module subscribes different channels for every agent types if possible. If there are only 2 channels, one agent type uses one channel and other two agent types use the other channel. Sample message coordinator reimplements the message priority based on the predefined priority of the the message. We also push the messages according to the type of the message. For example, CommandPolice message is sent only to the Police agent channel.

This pull request fixes #2.

