### PR TITLE
fixed correct config name for getting the refill rate

### DIFF
--- a/src/main/java/adf/agent/info/ScenarioInfo.java
+++ b/src/main/java/adf/agent/info/ScenarioInfo.java
@@ -175,7 +175,7 @@ public class ScenarioInfo {
 	}
 
 	public int getFireTankRefillRate() {
-		return this.config.getIntValue("fire.tank.refill-rate", 500);
+		return this.config.getIntValue("fire.tank.refill_rate", 500);
 	}
 
 	public int getKernelTimesteps() {


### PR DESCRIPTION
This fixes the bug that propagates from rcrs-server. https://github.com/roborescue/rcrs-server/issues/6 