### PR TITLE
:hammer: Fix module key name

### DIFF
--- a/src/main/java/adf/impl/tactics/DefaultTacticsFireStation.java
+++ b/src/main/java/adf/impl/tactics/DefaultTacticsFireStation.java
@@ -37,7 +37,7 @@ public class DefaultTacticsFireStation extends TacticsFireStation {
       case PRECOMPUTED:
       case NON_PRECOMPUTE:
         this.allocator = moduleManager.getModule(
-            "TacticsFireStation.TargetAllocator",
+            "DefaultTacticsFireStation.TargetAllocator",
             "adf.impl.module.complex.DefaultFireTargetAllocator");
         this.picker = moduleManager.getCommandPicker(
             "DefaultTacticsFireStation.CommandPicker",


### PR DESCRIPTION
Hello, this is Keisuke Ando from AIT. I've corrected the key used for calling the fire station module, which was incorrect. The current competition utilizes 'DefaultTactics', so the module cannot be called correctly. Additionally, this key does not match the config file provided by the ADF Sample Agents.