### PR TITLE
:bug: Fix incorrect path calculation method

### DIFF
--- a/src/main/java/adf/core/component/module/algorithm/PathPlanning.java
+++ b/src/main/java/adf/core/component/module/algorithm/PathPlanning.java
@@ -79,12 +79,12 @@ public abstract class PathPlanning extends AbstractModule {
       if (prevPoint != null) {
         int x = prevPoint.first() - point.first();
         int y = prevPoint.second() - point.second();
-        sum += x * x + y * y;
+        sum += Math.hypot(x, y);
       }
       prevPoint = point;
     }
 
-    return Math.sqrt(sum);
+    return sum;
   }
 
 


### PR DESCRIPTION
Fixed an error in the path length calculation process where the square root was incorrectly applied.