### PR TITLE
:bug: Utilize ExtActionMove for intended function

### DIFF
--- a/src/main/java/adf/impl/tactics/DefaultTacticsPoliceForce.java
+++ b/src/main/java/adf/impl/tactics/DefaultTacticsPoliceForce.java
@@ -198,7 +198,7 @@ public class DefaultTacticsPoliceForce extends TacticsPoliceForce {
     }
 
     target = this.search.calc().getTarget();
-    action = this.actionExtClear.setTarget(target).calc().getAction();
+    action = this.actionExtMove.setTarget(target).calc().getAction();
     if (action != null) {
       this.sendActionMessage(worldInfo, messageManager, agent, action);
       return action;


### PR DESCRIPTION
`ExtActionMove` is prepared but is not used. I fixed to match the DefaultTactitcs of other platoons. After agent decide target area for searching, agent should move to the target using `ExtActionMove`.