### PR TITLE
:bug: Fix NullPointerException in `MessageAmbulanceTeam` by using primitive field type

### DIFF
--- a/src/main/java/adf/core/agent/communication/standard/bundle/information/MessageAmbulanceTeam.java
+++ b/src/main/java/adf/core/agent/communication/standard/bundle/information/MessageAmbulanceTeam.java
@@ -28,12 +28,12 @@ public class MessageAmbulanceTeam extends StandardMessage {
 
   protected int rawAgentID;
   protected EntityID agentID;
-  protected Integer rawHumanPosition;
-  protected Integer humanHP;
-  protected Integer humanBuriedness;
-  protected Integer humanDamage;
+  protected int rawHumanPosition;
+  protected int humanHP;
+  protected int humanBuriedness;
+  protected int humanDamage;
   protected EntityID humanPosition;
-  protected Integer rawTargetID;
+  protected int rawTargetID;
   protected EntityID myTargetID;
   protected int myAction;
 


### PR DESCRIPTION
`MessageAmbulanceTeam` fields were decleared as an object type, which caused a `NullPointerException` in the following code:

```java
    } else if (this.rawTargetID != -1) {
```

https://github.com/NONONOexe/adf-core-java/blob/cbde8d8db0754255bcd6acfbc76e897f482631d1/src/main/java/adf/core/agent/communication/standard/bundle/information/MessageAmbulanceTeam.java#L159

The declearation has been changed to a primitive type. Other Message classes already use a primitive type, so this issue does not occur there.