### PR TITLE
feat: Upgrade to Java 21 and Gradle 9.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 ## 1. Software Pre-Requisites
 
-* Git
-* OpenJDK Java 17
-* Gradle
+- Git
+- OpenJDK Java 21
+- Gradle
 
 ## 2. Download
 

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,10 @@ defaultTasks 'build'
 
 group = 'com.github.roborescue'
 
-sourceCompatibility = '17'
-targetCompatibility = '17'
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
 version = '4.0'
 
 def getDateTime() {
@@ -42,7 +44,7 @@ repositories {
     url = 'https://repo.enonic.com/public/'
   }
   maven {
-    url 'https://jitpack.io'
+    url = 'https://jitpack.io'
   }
 }
 
@@ -90,21 +92,19 @@ clean{
 }
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-  classifier = 'javadoc'
+  archiveClassifier = 'javadoc'
   from javadoc.destinationDir
   archiveFileName = 'adf-core-javadoc.jar'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from sourceSets.main.allSource
   archiveFileName = 'adf-core-sources.jar'
 }
 
-artifacts {
-  archives sourcesJar
-  archives javadocJar
-}
+assemble.dependsOn sourcesJar
+assemble.dependsOn javadocJar
 
 task start (type: JavaExec) {
   classpath = sourceSets.main.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ java {
     sourceCompatibility = JavaVersion.VERSION_21
     targetCompatibility = JavaVersion.VERSION_21
 }
-version = '4.0'
+version = '5.0'
 
 def getDateTime() {
   new Date().format('yyyyMMddHHmmss', TimeZone.getTimeZone('UTC'))

--- a/build.gradle
+++ b/build.gradle
@@ -71,7 +71,7 @@ publishing {
   publications {
     maven(MavenPublication) {
       groupId = 'com.github.roborescue'
-      artifactId = 'adf-core'
+      artifactId = 'adf-core-java'
       version = 'master-SNAPSHOT'
 
       from components.java

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,4 @@
-before_install:
-  - source "$HOME/.sdkman/bin/sdkman-init.sh"
-  - sdk update
-  - sdk install java 17.0.1-tem
-  - sdk use java 17.0.1-tem
+jdk:
+  - openjdk21
+install:
+  - ./gradlew publishToMavenLocal -Dmaven.repo.local=$HOME/.m2/repository

--- a/src/main/java/adf/core/launcher/ConsoleOutput.java
+++ b/src/main/java/adf/core/launcher/ConsoleOutput.java
@@ -1,12 +1,14 @@
 package adf.core.launcher;
 
 import static adf.core.Main.VERSION_CODE;
-import adf.core.Main;
+
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.concurrent.Semaphore;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+
+import adf.core.Main;
 
 public class ConsoleOutput {
 
@@ -112,7 +114,7 @@ public class ConsoleOutput {
     String manifestPath = classPath.substring(0, classPath.lastIndexOf("!") + 1)
         + "/META-INF/MANIFEST.MF";
     try {
-      Manifest manifest = new Manifest(new URL(manifestPath).openStream());
+      Manifest manifest = new Manifest(URI.create(manifestPath).toURL().openStream());
       Attributes attributes = manifest.getMainAttributes();
       buildTimestamp = attributes.getValue("Build-Timestamp");
     } catch (IOException e) {


### PR DESCRIPTION
## Summary

The dependency `rcrs-server` migrated from Java 17 to Java 21, which caused builds to fail. This PR upgrades the project to Java 21 and Gradle 9.3.1 to restore compatibility. It also updates the artifact ID published to JitPack.

## Changes

### Upgrade to Java 21 & Gradle 9.3.1 (`f51b382`)

**`build.gradle`**
- Bumped Java version from 17 to 21 (migrated to the `java {}` block syntax)
- Replaced deprecated `classifier` property with `archiveClassifier`
- Replaced `artifacts {}` block with `assemble.dependsOn` (Gradle 9 deprecation)
- Updated repository URL assignments to use `=` syntax

**`gradle/wrapper/gradle-wrapper.properties`**
- Updated Gradle wrapper version from 7.3 to 9.3.1

**`jitpack.yml`**
- Replaced SDKMAN-based JDK setup with JitPack's native JDK declaration (`jdk: openjdk21`)
- Changed `install` command to `publishToMavenLocal`

**`src/main/java/adf/core/launcher/ConsoleOutput.java`**
- Replaced the deprecated `new URL(String)` constructor with `URI.create(...).toURL()` as required by Java 21

### Artifact ID Rename (`ab50f59`)

**`build.gradle`**
- Changed JitPack artifact ID from `adf-core` to `adf-core-java` to align with the repository name and make dependency declarations more explicit

## Release Notes

- Please create a Release for the current version (`v4.0`) before merging this PR.
- After merging, please bump the version and create a new Release.

## Checklist

- [x] `./gradlew build` passes